### PR TITLE
Some fixes to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,5 +8,6 @@ fi
 echo "Copying extension files..."
 mkdir -p ~/.local/share/gnome-shell/extensions
 cp -r dynamicTopBar@gnomeshell.feildel.fr ~/.local/share/gnome-shell/extensions
+
 echo "Enabling extension..."
 gnome-shell-extension-tool -e dynamicTopBar@gnomeshell.feildel.fr


### PR DESCRIPTION
The install file didn't check for availability of
gnome-shell-extension-tool or if the extension directory existed prior
to installation.

This pull fixes those small problems.

Cool extension otherwise!
