### PR TITLE
Better solution for the issue when a maximized window is closed

### DIFF
--- a/dynamicTopBar@gnomeshell.feildel.fr/extension.js
+++ b/dynamicTopBar@gnomeshell.feildel.fr/extension.js
@@ -262,7 +262,7 @@ function init() {
 function enable() {
 	preferences = Convenience.getSettings();
 	topPanelTransparencyManager = new PanelTransparencyManager(Main.panel, preferences.get_string('style'));
-	workspaceManager = new GlobalManager(topPanelTransparencyManager, preferences);
+	new GlobalManager(topPanelTransparencyManager, preferences);
 }
 
 function disable() {


### PR DESCRIPTION
I saw the solution @ianbrunelli gave for the issue of closing a maximized window, but look at the code I have noticed that the "for" he removed was necessary. Without it the closed window is not removed from the "windowList" and this array tends to get bigger as new windows are opened and then closed. The real problem was the call of the "destroy" method, which didn't exist.

Also, looking at the log I've found some warning caused by windows calling methods in an instance of "WorkspaceManager" the should have been destroyed. So I added a for loop to disconnect the windows in the list when the "WorkspaceManager" is destroyed.

Sorry if a misplaced some terminologies. I don't program in JS, so I don't know how people call somethings.
