### PR TITLE
Fix for depreciated GJS method in newest Clutter

### DIFF
--- a/dynamicTopBar@gnomeshell.feildel.fr/extension.js
+++ b/dynamicTopBar@gnomeshell.feildel.fr/extension.js
@@ -228,7 +228,7 @@ const WindowManager = new Lang.Class({
      * @return {Number} The monitor index
      */
     getMonitorIndex: function() {
-        return global.screen.get_monitor_index_for_rect(this._metaWindow.get_outer_rect());
+        return global.screen.get_monitor_index_for_rect(this._metaWindow.get_frame_rect());
     },
 
     /**


### PR DESCRIPTION
"metaWindow.get_outer_rect" was depreciated and with the latest Clutter update - the method finally broke. Please refer to this link from the GNOME GJS mailing list detailing this: https://mail.gnome.org/archives/commits-list/2014-October/msg01908.html.  

I don't know exactly when "metaWindow.get_frame_rect" was introduced into GJS - so I would not merge this in without testing.