### PR TITLE
Use MetaWindow.get_frame_rect()

### DIFF
--- a/dynamicTopBar@gnomeshell.feildel.fr/extension.js
+++ b/dynamicTopBar@gnomeshell.feildel.fr/extension.js
@@ -228,7 +228,7 @@ const WindowManager = new Lang.Class({
      * @return {Number} The monitor index
      */
     getMonitorIndex: function() {
-        return global.screen.get_monitor_index_for_rect(this._metaWindow.get_outer_rect());
+        return global.screen.get_monitor_index_for_rect(this._metaWindow.get_frame_rect());
     },
 
     /**


### PR DESCRIPTION
MetaWindow.get_outer_rect() has been deprecated for a while and was removed in Clutter 1.22, use the new function instead.

From: https://mail.gnome.org/archives/commits-list/2014-October/msg01908.html