### PR TITLE
fixed bug if theme has a border

### DIFF
--- a/dynamicTopBar@gnomeshell.feildel.fr/extension.js
+++ b/dynamicTopBar@gnomeshell.feildel.fr/extension.js
@@ -179,6 +179,7 @@ const PanelTransparencyManager = new Lang.Class({
                 style += 'background-gradient-start: rgba(0,0,0,0.8);';
                 style += 'background-gradient-end: rgba(0,0,0,0);';
                 style += 'background-gradient-direction: vertical;';
+				style += 'border-color: rgba(0,0,0,0);';
 
                 corner_style = '-panel-corner-background-color: transparent;';
             break;
@@ -186,6 +187,7 @@ const PanelTransparencyManager = new Lang.Class({
             case 'transparency':
             default:
                 style = 'background-color: rgba('+this._color.r+','+this._color.g+','+this._color.b+','+this._color.a+');';
+				style += 'border-color: rgba(0,0,0,0);';
 
                 corner_style = '-panel-corner-background-color: rgba('+this._color.r+','+this._color.g+','+this._color.b+','+this._color.a+');';
             break;

--- a/dynamicTopBar@gnomeshell.feildel.fr/extension.js
+++ b/dynamicTopBar@gnomeshell.feildel.fr/extension.js
@@ -179,7 +179,7 @@ const PanelTransparencyManager = new Lang.Class({
                 style += 'background-gradient-start: rgba(0,0,0,0.8);';
                 style += 'background-gradient-end: rgba(0,0,0,0);';
                 style += 'background-gradient-direction: vertical;';
-				style += 'border-color: rgba(0,0,0,0);';
+                style += 'border-color: rgba('+this._color.r+','+this._color.g+','+this._color.b+','+this._color.a+');';
 
                 corner_style = '-panel-corner-background-color: transparent;';
             break;
@@ -187,7 +187,7 @@ const PanelTransparencyManager = new Lang.Class({
             case 'transparency':
             default:
                 style = 'background-color: rgba('+this._color.r+','+this._color.g+','+this._color.b+','+this._color.a+');';
-				style += 'border-color: rgba(0,0,0,0);';
+                style += 'border-color: rgba('+this._color.r+','+this._color.g+','+this._color.b+','+this._color.a+');';
 
                 corner_style = '-panel-corner-background-color: rgba('+this._color.r+','+this._color.g+','+this._color.b+','+this._color.a+');';
             break;


### PR DESCRIPTION
the gnome shell theme i use (https://github.com/horst3180/Arc-theme/blob/master/common/gnome-shell/3.16/gnome-shell.css#L589) has a border on the panel, and i don't think it looks good to leave it there when the panel is transparent. if you could merge this into the main repo that'd be cool.

thanks,
Samuel Mercier