### PR TITLE
Added support for Gnome-shell 40

### DIFF
--- a/dynamicTopBar@gnomeshell.feildel.fr/metadata.json
+++ b/dynamicTopBar@gnomeshell.feildel.fr/metadata.json
@@ -10,7 +10,8 @@
     "3.20",
     "3.22",
     "3.30",
-    "3.34"
+    "3.34",
+    "40.0"
   ],
   "extension-id": "dynamic-top-bar",
   "settings-schema": "org.gnome.shell.extensions.dynamic-top-bar",


### PR DESCRIPTION
included gnome-shell 40 in metadata
PS: configure, doesn't work yet(use dconf). But the extension can be enabled on Gnome40